### PR TITLE
chore: adds issue and PR templates

### DIFF
--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/ISSUE_TEMPLATE/issue-template.md
+++ b/ISSUE_TEMPLATE/issue-template.md
@@ -1,0 +1,15 @@
+---
+name: Add a New Issue
+about: Use this template to raise an issue.
+title: "[Issue Title]"
+labels: 
+assignees:
+---
+
+### Expected Behavior
+
+Please describe the behavior you are expecting
+
+### Current Behavior
+
+What is the current behavior?

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,34 @@
+### Description
+
+_A few sentences describing the overall effects and goals of the pull request's commits.
+What is the current behavior, and what is the updated/expected behavior with this PR?_
+
+### Other changes
+
+_Describe any minor or "drive-by" changes here._
+
+### Tested
+
+_An explanation of how the changes were tested or an explanation as to why they don't need to be._
+
+### Related issues
+
+- closes [Linear ID, e.g. TON-123]
+
+<!-- Linear magic words
+
+1. Closing 
+  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
+  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
+2. Non-closing
+  1. ref, references, part of, related to, contributes to, towards
+  2. will not close the issue when the PR or commit merges
+-->
+
+### Backwards compatibility
+
+_Brief explanation of why these changes are/are not backwards compatible._
+
+### Documentation
+
+_The set of community facing docs that have been added/modified because of this change_


### PR DESCRIPTION
### Description

The goal of this PR is to add our PR and issue templates in this repo, so we automatically inherit them in all Tonk repos, for example [tonk-labs/gribi](https://github.com/tonk-labs/gribi). That simplifies eng best practices. More context on the [`.github` repository](https://www.freecodecamp.org/news/how-to-use-the-dot-github-repository/).

1. chore(.github): adds PR template
2. chore(.github): adds issue template

### Other changes

None

### Tested

No

### Related issues

N/A

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  3. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

No